### PR TITLE
Add UTC offset when adding extra content

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -68,7 +68,7 @@ func (p *Processor) computeExtraContent(msg message.Message) []byte {
 		if len(msg.Content()) > 0 && msg.Content()[0] != '<' {
 			// fit RFC5424
 			// <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %$!new-appname% - - - %msg%\n
-			timestamp := time.Now().Format("2006-01-02T15:04:05.000000+00:00")
+			timestamp := time.Now().UTC().Format("2006-01-02T15:04:05.000000+00:00")
 			extraContent := []byte("<46>0 ")
 			extraContent = append(extraContent, []byte(timestamp)...)
 			extraContent = append(extraContent, ' ')

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-log-agent/pkg/config"
 	"github.com/DataDog/datadog-log-agent/pkg/message"
@@ -88,10 +89,14 @@ func TestRedacting(t *testing.T) {
 func TestComputeExtraContent(t *testing.T) {
 	p := NewTestProcessor()
 	var extraContent []byte
+	var extraContentParts []string
 
 	source := &config.IntegrationConfigLogSource{TagsPayload: []byte{'-'}}
 	extraContent = p.computeExtraContent(message.NewNetworkMessage([]byte("message"), source))
-	assert.Equal(t, 8, len(strings.Split(string(extraContent), " ")))
+	extraContentParts = strings.Split(string(extraContent), " ")
+	assert.Equal(t, 8, len(extraContentParts))
+	format := "2006-01-02T15:04:05"
+	assert.Equal(t, time.Now().UTC().Format(format), extraContentParts[1][:len(format)])
 
 	extraContent = p.computeExtraContent(message.NewNetworkMessage([]byte("<message"), source))
 	assert.Nil(t, extraContent)

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -6,6 +6,7 @@
 package processor
 
 import (
+	"math"
 	"regexp"
 	"strings"
 	"testing"
@@ -99,7 +100,7 @@ func TestComputeExtraContent(t *testing.T) {
 	const format = "2006-01-02T15:04:05"
 	timestamp, err := time.Parse(format, extraContentParts[1][:len(format)])
 	assert.Nil(t, err)
-	assert.True(t, time.Since(timestamp).Minutes() < 1)
+	assert.True(t, math.Abs(time.Now().UTC().Sub(timestamp).Minutes()) < 1)
 
 	extraContent = p.computeExtraContent(message.NewNetworkMessage([]byte("<message"), source))
 	assert.Nil(t, extraContent)

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -95,8 +95,11 @@ func TestComputeExtraContent(t *testing.T) {
 	extraContent = p.computeExtraContent(message.NewNetworkMessage([]byte("message"), source))
 	extraContentParts = strings.Split(string(extraContent), " ")
 	assert.Equal(t, 8, len(extraContentParts))
-	format := "2006-01-02T15:04:05"
-	assert.Equal(t, time.Now().UTC().Format(format), extraContentParts[1][:len(format)])
+	// Pick the date string from the extra content parts and make sure it's within 1mn of the UTC time
+	const format = "2006-01-02T15:04:05"
+	timestamp, err := time.Parse(format, extraContentParts[1][:len(format)])
+	assert.Nil(t, err)
+	assert.True(t, time.Since(timestamp).Minutes() < 1)
 
 	extraContent = p.computeExtraContent(message.NewNetworkMessage([]byte("<message"), source))
 	assert.Nil(t, extraContent)


### PR DESCRIPTION
This small change adds the UTC offset to timestamp in the extra content added when building a message payload.