### PR TITLE
[Docker] Fix issue that would submit log twice on restart

### DIFF
--- a/pkg/input/container/docker_test.go
+++ b/pkg/input/container/docker_test.go
@@ -6,7 +6,6 @@
 package container
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -29,7 +28,6 @@ func (suite *DockerTailerTestSuite) TestDockerTailerRemovesDate() {
 	msgMeta[5] = '>'
 	msgMeta[6] = '1'
 	msgMeta[7] = 'g'
-	fmt.Println(msgMeta)
 
 	msg := []byte{}
 	for i := 0; i < len(msgMeta); i++ {
@@ -51,6 +49,12 @@ func (suite *DockerTailerTestSuite) TestDockerTailerRemovesDate() {
 	suite.Equal("my error", string(msg))
 	suite.Equal("error", sev)
 	suite.Equal("2008-01-12T01:01:01.000000000Z", ts)
+}
+
+func (suite *DockerTailerTestSuite) TestDockerTailerNextLogSinceDate() {
+	suite.Equal("2008-01-12T01:01:01.000000001Z", suite.tailer.nextLogSinceDate("2008-01-12T01:01:01.000000000Z"))
+	suite.Equal("2008-01-12T01:01:01.anything", suite.tailer.nextLogSinceDate("2008-01-12T01:01:01.anything"))
+	suite.Equal("", suite.tailer.nextLogSinceDate(""))
 }
 
 func (suite *DockerTailerTestSuite) TestDockerTailerIdentifier() {


### PR DESCRIPTION
For docker sources.
We store the time of the last log we sent, and start from that date.
Problem is that when we recover tailing, we start from that date
but it's inclusive, so the last log line is returned and sent twice.
A quick workaround is to add 1ns to the last time, so it becomes
exclusive. We can assume that we won't have two log lines with the
same timestamp (nanosecond precision), so we won't skip any log line
with this behavior


Compared old and new behavior, we can see that old behavior had 100% of submitting a log line twice upon restart, while new behavior is better (we still submit logs twice when we kill agent before it flushed the registry, but this should be solved by graceful shutdown).