### PR TITLE
Lechner/protect against empty hostnames

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,6 +68,11 @@ func buildMainConfig(config *viper.Viper, ddconfigPath, ddconfdPath string) erro
 		hostname = "unknown"
 	}
 	config.SetDefault("hostname", hostname)
+	if config.Get("hostname") == "" {
+			// logs get messed up if hostname is an empty string
+			// the agent 6 update script makes this a common problem
+			config.Set("hostname", hostname)
+	}
 
 	err = BuildLogsAgentIntegrationsConfigs(ddconfdPath)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"os"
 	"log"
 	"path/filepath"
 	"strings"
@@ -55,14 +56,16 @@ func buildMainConfig(config *viper.Viper, ddconfigPath, ddconfdPath string) erro
 	config.SetDefault("skip_ssl_validation", false)
 	config.SetDefault("run_path", "/opt/datadog-agent/run")
 
+	hostname, err := os.Hostname()
 	if isAgent5 {
 		// for agent5, we don't want people to have to set log_enabled in the config
 		config.SetDefault("log_enabled", true)
 	} else {
 		config.SetDefault("log_enabled", false)
+		// agent6 has a util.GetHostname() that agent5 does not have
+		hostname, err = util.GetHostname()
 	}
 
-	hostname, err := util.GetHostname()
 	if err != nil {
 		log.Println(err)
 		hostname = "unknown"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,11 +7,11 @@ package config
 
 import (
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/viper"
+	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 // MainConfig is the name of the main config file, while we haven't merged in dd agent
@@ -62,13 +62,13 @@ func buildMainConfig(config *viper.Viper, ddconfigPath, ddconfdPath string) erro
 		config.SetDefault("log_enabled", false)
 	}
 
-	hostname, err := os.Hostname()
+	hostname, err := util.GetHostname()
 	if err != nil {
 		log.Println(err)
 		hostname = "unknown"
 	}
 	config.SetDefault("hostname", hostname)
-	if config.Get("hostname") == "" {
+	if config.GetString("hostname") == "" {
 			// logs get messed up if hostname is an empty string
 			// the agent 6 update script makes this a common problem
 			config.Set("hostname", hostname)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -55,6 +56,18 @@ func TestBuildConfigWithIncompleteFile(t *testing.T) {
 	assert.Equal(t, 10516, testConfig.GetInt("log_dd_port"))
 	assert.Equal(t, false, testConfig.GetBool("skip_ssl_validation"))
 	assert.Equal(t, false, testConfig.GetBool("log_enabled"))
+}
+
+func TestBuildConfigWithEmptyStringHostname(t *testing.T) {
+	var testConfig = viper.New()
+	ddconfigPath := filepath.Join(testsPath, "emptystringhostname", "datadog.yaml")
+	ddconfdPath := filepath.Join(testsPath, "emptystringhostname", "conf.d")
+	buildMainConfig(testConfig, ddconfigPath, ddconfdPath)
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+	assert.Equal(t, hostname, testConfig.GetString("hostname"))
 }
 
 func TestComputeConfigWithMisconfiguredFile(t *testing.T) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,12 +6,12 @@
 package config
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/viper"
+	"github.com/spf13/viper"	
 	"github.com/stretchr/testify/assert"
+	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 const testsPath = "tests"
@@ -63,7 +63,7 @@ func TestBuildConfigWithEmptyStringHostname(t *testing.T) {
 	ddconfigPath := filepath.Join(testsPath, "emptystringhostname", "datadog.yaml")
 	ddconfdPath := filepath.Join(testsPath, "emptystringhostname", "conf.d")
 	buildMainConfig(testConfig, ddconfigPath, ddconfdPath)
-	hostname, err := os.Hostname()
+	hostname, err := util.GetHostname()
 	if err != nil {
 		hostname = "unknown"
 	}

--- a/pkg/config/tests/emptystringhostname/conf.d/integration.yaml
+++ b/pkg/config/tests/emptystringhostname/conf.d/integration.yaml
@@ -1,0 +1,12 @@
+init_config:
+
+instances:
+  - whatever: anything
+
+logs:
+  - type: file
+    path: /var/log/access.log
+    service: nginx
+    source: nginx
+    sourcecategory: http_access
+    tags: env:prod

--- a/pkg/config/tests/emptystringhostname/conf.d/integration2.yaml
+++ b/pkg/config/tests/emptystringhostname/conf.d/integration2.yaml
@@ -1,0 +1,14 @@
+init_config:
+
+instances:
+  - whatever: anything
+  
+logs:
+  - type: tcp
+    port: 10514
+    logset: devteam
+    log_processing_rules:
+      - type: mask_sequences
+        name: mocked_mask_rule
+        replace_placeholder: "[mocked]"
+        pattern: ".*" 

--- a/pkg/config/tests/emptystringhostname/conf.d/integration3.yaml
+++ b/pkg/config/tests/emptystringhostname/conf.d/integration3.yaml
@@ -1,0 +1,8 @@
+init_config:
+
+instances:
+  - whatever: anything
+
+logs:
+  - type: docker
+    image: test

--- a/pkg/config/tests/emptystringhostname/datadog.yaml
+++ b/pkg/config/tests/emptystringhostname/datadog.yaml
@@ -1,0 +1,7 @@
+log_dd_url: "my.url"
+log_dd_port: 10516
+skip_ssl_validation: true
+logset: playground
+api_key: "helloworld"
+hostname: ""
+log_enabled: true


### PR DESCRIPTION
Currently the agent 6 update script makes it very easy for the datadog.yaml to include `hostname: ""`. But this breaks the formatting of logs being sent to Datadog. This PR protects from `hostname: ""`, and instead defaults back to the hostname that the agent6 will find without any configured hostname. 

It also uses the `util.GetHostname` that the agent6 has. This confirms that the logs agent will use the same hostname as the core agent6. 

This PR makes this other PR moot: https://github.com/DataDog/datadog-log-agent/pull/7

That PR (7) applies the check in the `processor.go`, when it's probably more appropriate to have it in the `config.go`. That's fixed in this new PR. 