### PR TITLE
[Config] Hostname - don't set hostname to empty string

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,10 +7,10 @@ package config
 
 import (
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/spf13/viper"
 )
 
@@ -62,12 +62,16 @@ func buildMainConfig(config *viper.Viper, ddconfigPath, ddconfdPath string) erro
 		config.SetDefault("log_enabled", false)
 	}
 
-	hostname, err := os.Hostname()
-	if err != nil {
-		log.Println(err)
-		hostname = "unknown"
+	// For hostname, use value from config if set and non empty,
+	// or fallback on agent6's logic
+	if config.GetString("hostname") == "" {
+		hostname, err := util.GetHostname()
+		if err != nil {
+			log.Println(err)
+			hostname = "unknown"
+		}
+		config.Set("hostname", hostname)
 	}
-	config.SetDefault("hostname", hostname)
 
 	err = BuildLogsAgentIntegrationsConfigs(ddconfdPath)
 	if err != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
@@ -55,6 +56,8 @@ func TestBuildConfigWithIncompleteFile(t *testing.T) {
 	assert.Equal(t, 10516, testConfig.GetInt("log_dd_port"))
 	assert.Equal(t, false, testConfig.GetBool("skip_ssl_validation"))
 	assert.Equal(t, false, testConfig.GetBool("log_enabled"))
+	hostname, _ := util.GetHostname()
+	assert.Equal(t, hostname, testConfig.GetString("hostname"))
 }
 
 func TestComputeConfigWithMisconfiguredFile(t *testing.T) {

--- a/pkg/config/tests/incomplete/datadog.yaml
+++ b/pkg/config/tests/incomplete/datadog.yaml
@@ -1,0 +1,1 @@
+hostname: ""


### PR DESCRIPTION
When the hostname in config is set to `""`, agent6 discards that
value and recomputs it. Log-agent doesn't behave the same way, and
as a result it is confusing.
Let's instead match agent6's behavior.

This is specially important, as we have a script that converts
agent5 config to agent6 config, which defaults the hostname to `""`.