### PR TITLE
Changed logs-agent logs format to fix the severity and double timesta…

### DIFF
--- a/pkg/logagent/main.go
+++ b/pkg/logagent/main.go
@@ -12,6 +12,7 @@ import (
 	_ "net/http/pprof"
 
 	"github.com/DataDog/datadog-log-agent/pkg/config"
+	"github.com/DataDog/datadog-log-agent/pkg/utils"
 )
 
 var ddconfigPath = flag.String("ddconfig", "", "Path to the datadog.yaml configuration file")
@@ -20,6 +21,8 @@ var ddconfdPath = flag.String("ddconfd", "", "Path to the conf.d directory that 
 // main starts the logs agent
 func main() {
 	flag.Parse()
+
+	utils.SetupLogger()
 
 	err := config.BuildLogsAgentConfig(*ddconfigPath, *ddconfdPath)
 	if err != nil {

--- a/pkg/utils/logger.go
+++ b/pkg/utils/logger.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package utils
+
+import (
+	"fmt"
+	"log"
+)
+
+type logWriter struct {
+}
+
+func (w logWriter) Write(bytes []byte) (int, error) {
+	return fmt.Print(string(bytes))
+}
+
+func SetupLogger() {
+	log.SetFlags(0)
+	log.SetOutput(new(logWriter))
+}


### PR DESCRIPTION
Changed logs-agent logs format to fix the severity and double timestamp issue on logs in datadog-agent.