### PR TITLE
Multiline support

### DIFF
--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -22,6 +22,7 @@ const (
 	DOCKER_TYPE      = "docker"
 	EXCLUDE_AT_MATCH = "exclude_at_match"
 	MASK_SEQUENCES   = "mask_sequences"
+	MULTILINE        = "multi_line"
 )
 
 // LogsProcessingRule defines an exclusion or a masking rule to
@@ -169,6 +170,8 @@ func validateProcessingRules(rules []LogsProcessingRule) ([]LogsProcessingRule, 
 		case MASK_SEQUENCES:
 			rules[i].Reg = regexp.MustCompile(rule.Pattern)
 			rules[i].ReplacePlaceholderBytes = []byte(rule.ReplacePlaceholder)
+		case MULTILINE:
+			rules[i].Reg = regexp.MustCompile("^" + rule.Pattern)
 		default:
 			if rule.Type == "" {
 				return nil, fmt.Errorf("LogsAgent misconfigured: type must be set for log processing rule `%s`", rule.Name)

--- a/pkg/config/tests/complete/conf.d/integration4.yaml
+++ b/pkg/config/tests/complete/conf.d/integration4.yaml
@@ -1,0 +1,12 @@
+init_config:
+
+instances:
+  - whatever: anything
+  
+logs:
+  - type: file
+    path: /var/log/access.log    
+    log_processing_rules:
+      - type: multi_line
+        name: numbers        
+        pattern: "^[0-9]"

--- a/pkg/decoder/decoder.go
+++ b/pkg/decoder/decoder.go
@@ -8,12 +8,13 @@ package decoder
 import (
 	"bytes"
 	"regexp"
+	"time"
 
 	"github.com/DataDog/datadog-log-agent/pkg/config"
 	"github.com/DataDog/datadog-log-agent/pkg/message"
 )
 
-// Payload represents a list of bytes and an optional reference to its origin
+// Payload represents a list of bytes coming from a file and an optional reference to its origin
 type Payload struct {
 	content []byte
 	offset  int64
@@ -24,17 +25,20 @@ func NewPayload(content []byte, offset int64) *Payload {
 	return &Payload{content, offset}
 }
 
-// Decoder splits raw data based on `\n`, and sends those messages to a channel
+// Decoder splits raw data into messages using '\n' for single-line logs and re for multi-line logs
+// and sends them to a channel
 type Decoder struct {
 	InputChan  chan *Payload
 	OutputChan chan message.Message
+	lineBuffer *bytes.Buffer
 	msgBuffer  *bytes.Buffer
 	re         *regexp.Regexp
+	timer      *time.Timer
 	singleline bool
 }
 
 // InitializeDecoder returns a properly initialized Decoder
-func InitializedDecoder(source *config.IntegrationConfigLogSource) *Decoder {
+func InitializeDecoder(source *config.IntegrationConfigLogSource) *Decoder {
 	var singleline bool = true
 	var re *regexp.Regexp
 	for _, rule := range source.ProcessingRules {
@@ -52,10 +56,11 @@ func InitializedDecoder(source *config.IntegrationConfigLogSource) *Decoder {
 
 // New returns an initialized Decoder
 func New(InputChan chan *Payload, OutputChan chan message.Message, re *regexp.Regexp, singleline bool) *Decoder {
-	var msgBuf bytes.Buffer
+	var lineBuffer, msgBuf bytes.Buffer
 	return &Decoder{
 		InputChan:  InputChan,
 		OutputChan: OutputChan,
+		lineBuffer: &lineBuffer,
 		msgBuffer:  &msgBuf,
 		re:         re,
 		singleline: singleline,
@@ -67,25 +72,48 @@ func (d *Decoder) Start() {
 	go d.run()
 }
 
-// run lets the Decoder handle data coming from the InputChan
-func (d *Decoder) run() {
-	for data := range d.InputChan {
-		d.decodeIncomingData(data.content, data.offset)
-	}
-	d.OutputChan <- message.NewStopMessage()
-}
-
 // Stop stops the Decoder
 func (d *Decoder) Stop() {
 	close(d.InputChan)
 }
 
+// run lets the Decoder handle data coming from the InputChan
+func (d *Decoder) run() {
+	for data := range d.InputChan {
+		d.stopCountDown()
+		if ok, offset := d.decodeIncomingData(data.content, data.offset); ok {
+			d.restartCountDown(offset)
+		}
+	}
+	d.OutputChan <- message.NewStopMessage()
+}
+
+// waitingDuration represents the time after which the buffered line is sent when there is no more incoming data
+const waitingDuration = 1 * time.Second
+
+// stopCountDown prevents the timer for firing
+func (d *Decoder) stopCountDown() {
+	if d.timer != nil {
+		d.timer.Stop()
+	}
+}
+
+// restartCountDown starts the timer and sends the last line when it fires
+func (d *Decoder) restartCountDown(offset int64) {
+	d.timer = time.AfterFunc(waitingDuration, func() {
+		newLine := d.lineBuffer.Bytes()
+		defer d.lineBuffer.Reset()
+		d.msgBuffer.Write(newLine)
+		d.sendBufferedMessage(offset)
+	})
+}
+
 var truncatedMsg = []byte("...TRUNCATED...")
 var truncatedLen = len(truncatedMsg)
-var maxMessageLen = config.MaxMessageLen - truncatedLen
+var maxMessageLen = config.MaxMessageLen - 2*truncatedLen // worse case scenario being "...TRUNCATED...MSG...TRUNCATED..."
 
-// sendBuffuredMessage flushes the buffer and sends the message
-func (d *Decoder) sendBuffuredMessage(offset int64) {
+// sendBufferedMessage flushes the buffer and sends the message
+func (d *Decoder) sendBufferedMessage(offset int64) {
 	msg := make([]byte, d.msgBuffer.Len())
 	// d.msgBuffer.Bytes() returns a slice to the []byte, we thus need to copy it
 	copy(msg, d.msgBuffer.Bytes())
@@ -99,25 +127,103 @@ func (d *Decoder) sendBuffuredMessage(offset int64) {
 	d.msgBuffer.Reset()
 }
 
-// decodeIncomingData splits raw data based on `\n`, creates and sends messages to a channel
-func (d *Decoder) decodeIncomingData(inBuf []byte, offset int64) {
+// processBufferedLine checks the new line, appends the whole line or just a piece to the message
+// and sends the message if needed
+func (d *Decoder) processNewLine(offset int64) {
+	newLine := d.lineBuffer.Bytes()
+	defer d.lineBuffer.Reset()
+
+	if d.singleline {
+		d.msgBuffer.Write(newLine)
+		d.sendBufferedMessage(offset)
+		return
+	}
+
+	if d.msgBuffer.Len() == 0 {
+		d.msgBuffer.Write(newLine)
+		return
+	}
+
+	if d.re.Match(newLine) {
+		d.sendBufferedMessage(offset - int64(1+len(newLine))) // remove '\n' + new line length
+		d.msgBuffer.Write(newLine)
+		return
+	}
+
+	maxLen := maxMessageLen - d.msgBuffer.Len() - 1
+	if len(newLine) >= maxLen {
+		d.msgBuffer.Write([]byte(`\n`))
+		d.msgBuffer.Write(newLine[:maxLen])
+		d.msgBuffer.Write(truncatedMsg)
+		d.sendBufferedMessage(offset - int64(1+len(newLine[maxLen:]))) // remove '\n' + the length of the piece of the line that can't fit
+		d.msgBuffer.Write(truncatedMsg)
+		d.msgBuffer.Write(newLine[maxLen:])
+		return
+	}
+
+	// append a new line to the message
+	d.msgBuffer.Write([]byte(`\n`))
+	d.msgBuffer.Write(newLine)
+}
+
+// recoverTooLongBufferedLine truncates the new line and sends its left part and the message if needed
+func (d *Decoder) recoverTooLongBufferedLine(offset int64) {
+	newLine := d.lineBuffer.Bytes()
+	defer d.lineBuffer.Reset()
+
+	// truncate and send new line
+	truncAndSendLine := func() {
+		newLine = append(newLine, truncatedMsg...)
+		d.msgBuffer.Write(newLine)
+		d.sendBufferedMessage(offset)
+		d.msgBuffer.Write(truncatedMsg)
+	}
+
+	if d.singleline || d.msgBuffer.Len() == 0 {
+		truncAndSendLine()
+		return
+	}
+
+	if d.re.Match(newLine) {
+		d.sendBufferedMessage(offset - int64(len(newLine)))
+		truncAndSendLine()
+		return
+	}
+
+	maxLen := maxMessageLen - d.msgBuffer.Len() - 1
+	d.msgBuffer.Write([]byte(`\n`))
+	d.msgBuffer.Write(newLine[:maxLen])
+	d.msgBuffer.Write(truncatedMsg)
+	d.sendBufferedMessage(offset - int64(len(newLine[maxLen:]))) // remove the length of the line that can't fit
+	d.msgBuffer.Write(truncatedMsg)
+	d.msgBuffer.Write(newLine[maxLen:])
+}
+
+// decodeIncomingData splits raw data based on `\n`, creates and processes new lines
+// returns true and the new offset if the end of inBuf is likely to be the end of a message
+func (d *Decoder) decodeIncomingData(inBuf []byte, offset int64) (ok bool, newOffset int64) {
 	var i, j = 0, 0
-	var maxj = maxMessageLen - d.msgBuffer.Len()
-	// Note: we will truncate messages of length MaxLen - truncatedLen
+	var maxj = maxMessageLen - d.lineBuffer.Len()
+	// Note: we will truncate messages of length MaxLen - 2*truncatedLen
 	// instead of MaxLen. We'll live with it for now
 	for ; j < len(inBuf); j++ {
 		if inBuf[j] == '\n' {
-			d.msgBuffer.Write(inBuf[i:j])
-			d.sendBuffuredMessage(offset + int64(j+1))
+			d.lineBuffer.Write(inBuf[i:j])
+			d.processNewLine(offset + int64(j+1))
 			i = j + 1 // +1 as we skip the `\n`
-			maxj = maxMessageLen - d.msgBuffer.Len()
+			maxj = maxMessageLen - d.lineBuffer.Len()
 		} else if j == maxj {
-			d.msgBuffer.Write(inBuf[i:j])
-			d.msgBuffer.Write(truncatedMsg)
-			d.sendBuffuredMessage(offset + int64(j))
-			d.msgBuffer.Write(truncatedMsg)
+			d.lineBuffer.Write(inBuf[i:j])
+			d.recoverTooLongBufferedLine(offset + int64(j))
 			i = j
+			maxj = maxMessageLen - d.lineBuffer.Len()
 		}
 	}
-	d.msgBuffer.Write(inBuf[i:j])
+	d.lineBuffer.Write(inBuf[i:j])
+
+	if len(inBuf) > 0 && inBuf[j-1] == '\n' {
+		ok = true
+	}
+	newOffset = offset + int64(j)
+	return ok, newOffset
 }

--- a/pkg/decoder/decoder_test.go
+++ b/pkg/decoder/decoder_test.go
@@ -23,13 +23,13 @@ func TestDecodeIncomingDataForSingleLineLogs(t *testing.T) {
 	var out message.Message
 
 	// multiple messages in one buffer
-	d.decodeIncomingData([]byte("helloworld\n"))
+	d.decodeIncomingData([]byte("helloworld\n"), nil)
 	out = <-outChan
 	assert.Equal(t, "helloworld", string(out.Content()))
 	assert.Equal(t, "", d.lineBuffer.String())
 	assert.Equal(t, "", d.msgBuffer.String())
 
-	d.decodeIncomingData([]byte("helloworld\nhowayou\ngoodandyou"))
+	d.decodeIncomingData([]byte("helloworld\nhowayou\ngoodandyou"), nil)
 	out = <-outChan
 	assert.Equal(t, "helloworld", string(out.Content()))
 	out = <-outChan
@@ -39,9 +39,9 @@ func TestDecodeIncomingDataForSingleLineLogs(t *testing.T) {
 	d.lineBuffer.Reset()
 
 	// messages overflow in the next buffer
-	d.decodeIncomingData([]byte("helloworld\nthisisa"))
+	d.decodeIncomingData([]byte("helloworld\nthisisa"), nil)
 	assert.Equal(t, "thisisa", d.lineBuffer.String())
-	d.decodeIncomingData([]byte("longinput\nindeed"))
+	d.decodeIncomingData([]byte("longinput\nindeed"), nil)
 	out = <-outChan
 	out = <-outChan
 	assert.Equal(t, "thisisalonginput", string(out.Content()))
@@ -49,27 +49,27 @@ func TestDecodeIncomingDataForSingleLineLogs(t *testing.T) {
 	d.lineBuffer.Reset()
 
 	// edge cases, do not crash
-	d.decodeIncomingData([]byte("\n\n"))
-	d.decodeIncomingData([]byte(""))
+	d.decodeIncomingData([]byte("\n\n"), nil)
+	d.decodeIncomingData([]byte(""), nil)
 
 	// buffer overflow
 	d.lineBuffer.Reset()
-	d.decodeIncomingData([]byte("hello world"))
-	d.decodeIncomingData([]byte("!\n"))
+	d.decodeIncomingData([]byte("hello world"), nil)
+	d.decodeIncomingData([]byte("!\n"), nil)
 	out = <-outChan
 	assert.Equal(t, "hello world!", string(out.Content()))
 
 	// message too big
 	d.lineBuffer.Reset()
-	d.decodeIncomingData([]byte(strings.Repeat("a", maxMessageLen+5) + "\n"))
+	d.decodeIncomingData([]byte(strings.Repeat("a", maxMessageLen+5)+"\n"), nil)
 	out = <-outChan
 	assert.Equal(t, maxMessageLen, len(out.Content()))
 	out = <-outChan
 	assert.Equal(t, strings.Repeat("a", 5), string(out.Content()))
 
 	// message too big, over several calls
-	d.decodeIncomingData([]byte(strings.Repeat("a", maxMessageLen-5)))
-	d.decodeIncomingData([]byte(strings.Repeat("a", 25) + "\n"))
+	d.decodeIncomingData([]byte(strings.Repeat("a", maxMessageLen-5)), nil)
+	d.decodeIncomingData([]byte(strings.Repeat("a", 25)+"\n"), nil)
 	out = <-outChan
 	assert.Equal(t, maxMessageLen, len(out.Content()))
 	out = <-outChan
@@ -77,7 +77,7 @@ func TestDecodeIncomingDataForSingleLineLogs(t *testing.T) {
 
 	// message twice too big
 	d.lineBuffer.Reset()
-	d.decodeIncomingData([]byte(strings.Repeat("a", 2*maxMessageLen+5) + "\n"))
+	d.decodeIncomingData([]byte(strings.Repeat("a", 2*maxMessageLen+5)+"\n"), nil)
 	out = <-outChan
 	assert.Equal(t, maxMessageLen, len(out.Content()))
 	out = <-outChan
@@ -87,14 +87,32 @@ func TestDecodeIncomingDataForSingleLineLogs(t *testing.T) {
 
 	// message twice too big, over several calls
 	d.lineBuffer.Reset()
-	d.decodeIncomingData([]byte(strings.Repeat("a", maxMessageLen+5)))
-	d.decodeIncomingData([]byte(strings.Repeat("a", maxMessageLen+5) + "\n"))
+	d.decodeIncomingData([]byte(strings.Repeat("a", maxMessageLen+5)), nil)
+	d.decodeIncomingData([]byte(strings.Repeat("a", maxMessageLen+5)+"\n"), nil)
 	out = <-outChan
 	assert.Equal(t, maxMessageLen, len(out.Content()))
 	out = <-outChan
 	assert.Equal(t, maxMessageLen, len(out.Content()))
 	out = <-outChan
 	assert.Equal(t, strings.Repeat("a", 10), string(out.Content()))
+
+	// decoder context management
+	var mockPayloadContext MockPayloadContext
+
+	mockPayloadContext = MockPayloadContext{}
+	d.decodeIncomingData([]byte("helloworld\nthisisa"), &mockPayloadContext)
+	assert.Equal(t, "helloworld\n", string(mockPayloadContext.Message))
+	assert.Equal(t, "", string(mockPayloadContext.Content))
+
+	mockPayloadContext = MockPayloadContext{}
+	d.decodeIncomingData([]byte("helloworld"), &mockPayloadContext)
+	assert.Equal(t, "", string(mockPayloadContext.Content))
+	assert.Equal(t, "", string(mockPayloadContext.Message))
+
+	mockPayloadContext = MockPayloadContext{}
+	d.decodeIncomingData([]byte(strings.Repeat("a", maxMessageLen+5)), &mockPayloadContext)
+	assert.Equal(t, maxMessageLen, len(mockPayloadContext.Message))
+	assert.Equal(t, "", string(mockPayloadContext.Content))
 }
 
 func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
@@ -107,14 +125,14 @@ func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
 	go d.run()
 
 	// two lines message in one raw data
-	inChan <- NewPayload([]byte("1. Hello\nworld!\n"))
+	inChan <- NewPayload([]byte("1. Hello\nworld!\n"), nil)
 	out = <-outChan
 	assert.Equal(t, "1. Hello\\nworld!", string(out.Content()))
 	assert.Equal(t, "", d.lineBuffer.String())
 	assert.Equal(t, "", d.msgBuffer.String())
 
 	// multiple messages in one raw data
-	inChan <- NewPayload([]byte("1. Hello\nworld!\n2. How are you\n"))
+	inChan <- NewPayload([]byte("1. Hello\nworld!\n2. How are you\n"), nil)
 	out = <-outChan
 	assert.Equal(t, "1. Hello\\nworld!", string(out.Content()))
 	out = <-outChan
@@ -123,16 +141,16 @@ func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
 	assert.Equal(t, "", d.msgBuffer.String())
 
 	// two lines message over two raw data
-	inChan <- NewPayload([]byte("1. Hello\n"))
-	inChan <- NewPayload([]byte("world!\n"))
+	inChan <- NewPayload([]byte("1. Hello\n"), nil)
+	inChan <- NewPayload([]byte("world!\n"), nil)
 	out = <-outChan
 	assert.Equal(t, "1. Hello\\nworld!", string(out.Content()))
 	assert.Equal(t, "", d.lineBuffer.String())
 	assert.Equal(t, "", d.msgBuffer.String())
 
 	// multiple messages accross two raw data
-	inChan <- NewPayload([]byte("1. Hello\n"))
-	inChan <- NewPayload([]byte("world!\n2. How are you\n"))
+	inChan <- NewPayload([]byte("1. Hello\n"), nil)
+	inChan <- NewPayload([]byte("world!\n2. How are you\n"), nil)
 	out = <-outChan
 	assert.Equal(t, "1. Hello\\nworld!", string(out.Content()))
 	out = <-outChan
@@ -141,14 +159,14 @@ func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
 	assert.Equal(t, "", d.msgBuffer.String())
 
 	// single-line message in one raw data
-	inChan <- NewPayload([]byte("1. Hello world!\n"))
+	inChan <- NewPayload([]byte("1. Hello world!\n"), nil)
 	out = <-outChan
 	assert.Equal(t, "1. Hello world!", string(out.Content()))
 	assert.Equal(t, "", d.lineBuffer.String())
 	assert.Equal(t, "", d.msgBuffer.String())
 
 	// multiple single-line messages in one raw data
-	inChan <- NewPayload([]byte("1. Hello world!\n2. How are you\n"))
+	inChan <- NewPayload([]byte("1. Hello world!\n2. How are you\n"), nil)
 	out = <-outChan
 	assert.Equal(t, "1. Hello world!", string(out.Content()))
 	out = <-outChan
@@ -157,22 +175,22 @@ func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
 	assert.Equal(t, "", d.msgBuffer.String())
 
 	// two lines big message in one raw data
-	inChan <- NewPayload([]byte("12345678.\n" + strings.Repeat("a", maxMessageLen-5) + "\n"))
+	inChan <- NewPayload([]byte("12345678.\n"+strings.Repeat("a", maxMessageLen-5)+"\n"), nil)
 	out = <-outChan
 	assert.Equal(t, "12345678.", string(out.Content()))
 	out = <-outChan
 	assert.Equal(t, +maxMessageLen-5, len(out.Content()))
 
 	// two lines big message over two raw data
-	inChan <- NewPayload([]byte("12345678.\n"))
-	inChan <- NewPayload([]byte(strings.Repeat("a", maxMessageLen-5) + "\n"))
+	inChan <- NewPayload([]byte("12345678.\n"), nil)
+	inChan <- NewPayload([]byte(strings.Repeat("a", maxMessageLen-5)+"\n"), nil)
 	out = <-outChan
 	assert.Equal(t, "12345678.", string(out.Content()))
 	out = <-outChan
 	assert.Equal(t, +maxMessageLen-5, len(out.Content()))
 
 	// two lines too big message in one raw data
-	inChan <- NewPayload([]byte("12345678.\n" + strings.Repeat("a", maxMessageLen+5) + "\n"))
+	inChan <- NewPayload([]byte("12345678.\n"+strings.Repeat("a", maxMessageLen+5)+"\n"), nil)
 	out = <-outChan
 	assert.Equal(t, "12345678.", string(out.Content()))
 	out = <-outChan
@@ -180,22 +198,22 @@ func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
 	assert.Equal(t, strings.Repeat("a", 5), string(out.Content()))
 
 	// single-line big message over two raw data
-	inChan <- NewPayload([]byte(strings.Repeat("a", maxMessageLen)))
-	inChan <- NewPayload([]byte(strings.Repeat("a", 5) + "\n"))
+	inChan <- NewPayload([]byte(strings.Repeat("a", maxMessageLen)), nil)
+	inChan <- NewPayload([]byte(strings.Repeat("a", 5)+"\n"), nil)
 	out = <-outChan
 	assert.Equal(t, maxMessageLen, len(out.Content()))
 	out = <-outChan
 	assert.Equal(t, strings.Repeat("a", 5), string(out.Content()))
 
 	// single-line too big message in one raw data
-	inChan <- NewPayload([]byte(strings.Repeat("a", maxMessageLen+5) + "\n"))
+	inChan <- NewPayload([]byte(strings.Repeat("a", maxMessageLen+5)+"\n"), nil)
 	out = <-outChan
 	assert.Equal(t, maxMessageLen, len(out.Content()))
 	out = <-outChan
 	assert.Equal(t, strings.Repeat("a", 5), string(out.Content()))
 
 	// message twice too big in one raw data
-	inChan <- NewPayload([]byte(strings.Repeat("a", 2*maxMessageLen+5) + "\n"))
+	inChan <- NewPayload([]byte(strings.Repeat("a", 2*maxMessageLen+5)+"\n"), nil)
 	out = <-outChan
 	assert.Equal(t, maxMessageLen, len(out.Content()))
 	out = <-outChan
@@ -204,8 +222,8 @@ func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
 	assert.Equal(t, strings.Repeat("a", 5), string(out.Content()))
 
 	// message twice too big over two raw data
-	inChan <- NewPayload([]byte(strings.Repeat("a", maxMessageLen+5)))
-	inChan <- NewPayload([]byte(strings.Repeat("a", maxMessageLen+5) + "\n"))
+	inChan <- NewPayload([]byte(strings.Repeat("a", maxMessageLen+5)), nil)
+	inChan <- NewPayload([]byte(strings.Repeat("a", maxMessageLen+5)+"\n"), nil)
 	out = <-outChan
 	assert.Equal(t, maxMessageLen, len(out.Content()))
 	out = <-outChan
@@ -214,7 +232,7 @@ func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
 	assert.Equal(t, strings.Repeat("a", 10), string(out.Content()))
 
 	// pending message in one raw data
-	inChan <- NewPayload([]byte(("1. Hello world!")))
+	inChan <- NewPayload([]byte(("1. Hello world!")), nil)
 	timeout := time.NewTimer(1*time.Second + 1*time.Millisecond)
 	select {
 	case out = <-outChan:
@@ -222,6 +240,49 @@ func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
 	case <-timeout.C:
 		break
 	}
+
+	// decoder context management
+	var mockPayloadContext MockPayloadContext
+
+	d.lineBuffer.Reset()
+	d.msgBuffer.Reset()
+
+	mockPayloadContext = MockPayloadContext{}
+	d.decodeIncomingData([]byte("helloworld\nthisisa"), &mockPayloadContext)
+	assert.Equal(t, "helloworld\n", string(mockPayloadContext.Content))
+	assert.Equal(t, "", string(mockPayloadContext.Message))
+
+	d.lineBuffer.Reset()
+	d.msgBuffer.Reset()
+
+	mockPayloadContext = MockPayloadContext{}
+	d.decodeIncomingData([]byte("helloworld\nthisisa\nmessage"), &mockPayloadContext)
+	assert.Equal(t, "helloworld\nthisisa\n", string(mockPayloadContext.Content))
+	assert.Equal(t, "", string(mockPayloadContext.Message))
+
+	d.lineBuffer.Reset()
+	d.msgBuffer.Reset()
+
+	mockPayloadContext = MockPayloadContext{}
+	d.decodeIncomingData([]byte("helloworld\nthisisa\n123.message\n"), &mockPayloadContext)
+	assert.Equal(t, "helloworld\nthisisa\n", string(mockPayloadContext.Message))
+	assert.Equal(t, "123.message\n", string(mockPayloadContext.Content))
+
+	d.lineBuffer.Reset()
+	d.msgBuffer.Reset()
+
+	mockPayloadContext = MockPayloadContext{}
+	d.decodeIncomingData([]byte("helloworld"), &mockPayloadContext)
+	assert.Equal(t, "", string(mockPayloadContext.Content))
+	assert.Equal(t, "", string(mockPayloadContext.Message))
+
+	d.lineBuffer.Reset()
+	d.msgBuffer.Reset()
+
+	mockPayloadContext = MockPayloadContext{}
+	d.decodeIncomingData([]byte(strings.Repeat("a", maxMessageLen+5)+"\n"), &mockPayloadContext)
+	assert.Equal(t, maxMessageLen, len(mockPayloadContext.Message))
+	assert.Equal(t, strings.Repeat("a", 5), string(mockPayloadContext.Content))
 }
 
 func TestDecoderLifecycle(t *testing.T) {
@@ -231,7 +292,7 @@ func TestDecoderLifecycle(t *testing.T) {
 	d.Start()
 	var out message.Message
 
-	inChan <- NewPayload([]byte("helloworld\n"))
+	inChan <- NewPayload([]byte("helloworld\n"), nil)
 	out = <-outChan
 	assert.Equal(t, "helloworld", string(out.Content()))
 

--- a/pkg/decoder/decoder_test.go
+++ b/pkg/decoder/decoder_test.go
@@ -7,17 +7,19 @@ package decoder
 
 import (
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-log-agent/pkg/config"
 	"github.com/DataDog/datadog-log-agent/pkg/message"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDecodeIncomingData(t *testing.T) {
+func TestDecodeIncomingDataForSingleLineLogs(t *testing.T) {
 	outChan := make(chan message.Message, 10)
-	d := New(nil, outChan)
+	d := New(nil, outChan, time.Millisecond, nil, true)
 
 	var out message.Message
 
@@ -25,40 +27,41 @@ func TestDecodeIncomingData(t *testing.T) {
 	d.decodeIncomingData([]byte(("helloworld\n")), 0)
 	out = <-outChan
 	assert.Equal(t, "helloworld", string(out.Content()))
+	assert.Equal(t, "", d.lineBuffer.String())
 	assert.Equal(t, "", d.msgBuffer.String())
-	d.msgBuffer.Reset()
 
 	d.decodeIncomingData([]byte(("helloworld\nhowayou\ngoodandyou")), 0)
 	out = <-outChan
 	assert.Equal(t, "helloworld", string(out.Content()))
 	out = <-outChan
 	assert.Equal(t, "howayou", string(out.Content()))
-	assert.Equal(t, "goodandyou", d.msgBuffer.String())
-	d.msgBuffer.Reset()
+	assert.Equal(t, "goodandyou", d.lineBuffer.String())
+	assert.Equal(t, "", d.msgBuffer.String())
+	d.lineBuffer.Reset()
 
 	// messages overflow in the next buffer
 	d.decodeIncomingData([]byte(("helloworld\nthisisa")), 5)
-	assert.Equal(t, "thisisa", d.msgBuffer.String())
+	assert.Equal(t, "thisisa", d.lineBuffer.String())
 	d.decodeIncomingData([]byte(("longinput\nindeed")), 15)
 	out = <-outChan
 	out = <-outChan
 	assert.Equal(t, "thisisalonginput", string(out.Content()))
-	assert.Equal(t, "indeed", d.msgBuffer.String())
-	d.msgBuffer.Reset()
+	assert.Equal(t, "indeed", d.lineBuffer.String())
+	d.lineBuffer.Reset()
 
 	// edge cases, do not crash
 	d.decodeIncomingData([]byte(("\n\n")), 0)
 	d.decodeIncomingData([]byte(("")), 0)
 
 	// buffer overflow
-	d.msgBuffer.Reset()
+	d.lineBuffer.Reset()
 	d.decodeIncomingData([]byte(("hello world")), 0)
 	d.decodeIncomingData([]byte(("!\n")), 0)
 	out = <-outChan
 	assert.Equal(t, "hello world!", string(out.Content()))
 
 	// message too big
-	d.msgBuffer.Reset()
+	d.lineBuffer.Reset()
 	d.decodeIncomingData([]byte((strings.Repeat("a", config.MaxMessageLen+5) + "\n")), 0)
 	out = <-outChan
 	assert.Equal(t, config.MaxMessageLen, len(out.Content()))
@@ -74,13 +77,13 @@ func TestDecodeIncomingData(t *testing.T) {
 	assert.Equal(t, "...TRUNCATED..."+strings.Repeat("a", 20), string(out.Content()))
 
 	// message too big
-	d.msgBuffer.Reset()
+	d.lineBuffer.Reset()
 	d.decodeIncomingData([]byte((strings.Repeat("a", config.MaxMessageLen-15) + "\n")), 0)
 	out = <-outChan
 	assert.Equal(t, config.MaxMessageLen-15, len(out.Content()))
 
 	// decoder offset management
-	d.msgBuffer.Reset()
+	d.lineBuffer.Reset()
 	d.decodeIncomingData([]byte(("6789\n121416182022\n2527")), 5)
 	d.decodeIncomingData([]byte(("29\n")), 27)
 	out = <-outChan
@@ -91,10 +94,98 @@ func TestDecodeIncomingData(t *testing.T) {
 	assert.Equal(t, int64(30), out.GetOrigin().Offset)
 }
 
+func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
+	inChan := make(chan *Payload, 10)
+	outChan := make(chan message.Message, 10)
+	re := regexp.MustCompile("[0-9]+\\.")
+	singleLine := false
+	d := New(inChan, outChan, time.Millisecond, re, singleLine)
+
+	var out message.Message
+	go d.run()
+
+	// simple message in one raw data
+	inChan <- NewPayload([]byte("1. Hello\nworld!\n"), 5)
+	out = <-outChan
+	assert.Equal(t, "1. Hello\\nworld!", string(out.Content()))
+	assert.Equal(t, int64(21), out.GetOrigin().Offset)
+	assert.Equal(t, "", d.lineBuffer.String())
+	assert.Equal(t, "", d.msgBuffer.String())
+
+	// multiple messages in one raw data
+	inChan <- NewPayload([]byte("1. Hello\nworld!\n2. How are you\n"), 5)
+	out = <-outChan
+	assert.Equal(t, "1. Hello\\nworld!", string(out.Content()))
+	assert.Equal(t, int64(21), out.GetOrigin().Offset)
+	out = <-outChan
+	assert.Equal(t, "2. How are you", string(out.Content()))
+	assert.Equal(t, int64(36), out.GetOrigin().Offset)
+	assert.Equal(t, "", d.lineBuffer.String())
+	assert.Equal(t, "", d.msgBuffer.String())
+
+	// simple message across two raw data
+	inChan <- NewPayload([]byte("1. Hello\n"), 5)
+	inChan <- NewPayload([]byte("world!\n"), 14)
+	out = <-outChan
+	assert.Equal(t, "1. Hello\\nworld!", string(out.Content()))
+	assert.Equal(t, int64(21), out.GetOrigin().Offset)
+	assert.Equal(t, "", d.lineBuffer.String())
+	assert.Equal(t, "", d.msgBuffer.String())
+
+	// multiple messages accross two raw data
+	inChan <- NewPayload([]byte("1. Hello\n"), 5)
+	inChan <- NewPayload([]byte("world!\n2. How are you\n"), 14)
+	out = <-outChan
+	assert.Equal(t, "1. Hello\\nworld!", string(out.Content()))
+	assert.Equal(t, int64(21), out.GetOrigin().Offset)
+	out = <-outChan
+	assert.Equal(t, "2. How are you", string(out.Content()))
+	assert.Equal(t, int64(36), out.GetOrigin().Offset)
+	assert.Equal(t, "", d.lineBuffer.String())
+	assert.Equal(t, "", d.msgBuffer.String())
+
+	// single-line message in one raw data
+	inChan <- NewPayload([]byte("1. Hello world!\n"), 5)
+	out = <-outChan
+	assert.Equal(t, "1. Hello world!", string(out.Content()))
+	assert.Equal(t, int64(21), out.GetOrigin().Offset)
+	assert.Equal(t, "", d.lineBuffer.String())
+	assert.Equal(t, "", d.msgBuffer.String())
+
+	// multiple single-line messages in one raw data
+	inChan <- NewPayload([]byte("1. Hello world!\n2. How are you\n"), 5)
+	out = <-outChan
+	assert.Equal(t, "1. Hello world!", string(out.Content()))
+	assert.Equal(t, int64(21), out.GetOrigin().Offset)
+	out = <-outChan
+	assert.Equal(t, "2. How are you", string(out.Content()))
+	assert.Equal(t, int64(36), out.GetOrigin().Offset)
+	assert.Equal(t, "", d.lineBuffer.String())
+	assert.Equal(t, "", d.msgBuffer.String())
+
+	// big message across two lines
+	inChan <- NewPayload([]byte("123456789\n"), 5)
+	inChan <- NewPayload([]byte(strings.Repeat("a", maxMessageLen-6)+"\n"), 25)
+	out = <-outChan
+	assert.Equal(t, config.MaxMessageLen, len(out.Content()))
+	out = <-outChan
+	assert.Equal(t, "...TRUNCATED..."+strings.Repeat("a", 5), string(out.Content()))
+
+	// pending message in one raw data
+	inChan <- NewPayload([]byte(("1. Hello world!")), 5)
+	timeout := time.NewTimer(1*time.Second + 1*time.Millisecond)
+	select {
+	case out = <-outChan:
+		assert.Fail(t, "did not expect message, got ", out)
+	case <-timeout.C:
+		break
+	}
+}
+
 func TestDecoderLifecycle(t *testing.T) {
 	inChan := make(chan *Payload, 10)
 	outChan := make(chan message.Message, 10)
-	d := New(inChan, outChan)
+	d := New(inChan, outChan, time.Millisecond, nil, true)
 	d.Start()
 	var out message.Message
 

--- a/pkg/decoder/decoder_test.go
+++ b/pkg/decoder/decoder_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestDecodeIncomingDataForSingleLineLogs(t *testing.T) {
 	outChan := make(chan message.Message, 10)
-	d := New(nil, outChan, time.Millisecond, nil, true)
+	d := New(nil, outChan, time.Millisecond, false, nil)
 
 	var out message.Message
 
@@ -98,8 +98,7 @@ func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
 	inChan := make(chan *Payload, 10)
 	outChan := make(chan message.Message, 10)
 	re := regexp.MustCompile("[0-9]+\\.")
-	singleLine := false
-	d := New(inChan, outChan, time.Millisecond, re, singleLine)
+	d := New(inChan, outChan, time.Millisecond, true, re)
 
 	var out message.Message
 	go d.run()
@@ -185,7 +184,7 @@ func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
 func TestDecoderLifecycle(t *testing.T) {
 	inChan := make(chan *Payload, 10)
 	outChan := make(chan message.Message, 10)
-	d := New(inChan, outChan, time.Millisecond, nil, true)
+	d := New(inChan, outChan, time.Millisecond, false, nil)
 	d.Start()
 	var out message.Message
 

--- a/pkg/decoder/payload.go
+++ b/pkg/decoder/payload.go
@@ -1,0 +1,53 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package decoder
+
+import (
+	"github.com/DataDog/datadog-log-agent/pkg/message"
+)
+
+// PayloadContext can create new message.MessageOrigin from a msg
+// and be updated with content
+type PayloadContext interface {
+	messageOrigin() *message.MessageOrigin
+	update(content []byte)
+}
+
+// Payload represents a list of bytes with a context
+type Payload struct {
+	content []byte
+	context PayloadContext
+}
+
+// NewPayload returns a new decoder payload
+func NewPayload(content []byte, context PayloadContext) *Payload {
+	return &Payload{content, context}
+}
+
+// FileContext is an implementation of PayloadContext for files
+// it holds the offset from where we should seek in the file when restarting logs-agent
+type FileContext struct {
+	offset int64
+}
+
+// NewFileContext creates a new FileContext
+func NewFileContext(offset int64) *FileContext {
+	return &FileContext{offset}
+}
+
+// messageOrigin computes a new message.MessageOrigin with an offset
+// pointing to where we should seek in the file when restrarting logs-agent
+func (c FileContext) messageOrigin() *message.MessageOrigin {
+	o := message.NewOrigin()
+	o.Offset = c.offset
+	return o
+}
+
+// update changes the offset to point to the end of the content
+func (c *FileContext) update(content []byte) {
+	offset := c.offset + int64(len(content))
+	c.offset = offset
+}

--- a/pkg/decoder/payload_test.go
+++ b/pkg/decoder/payload_test.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package decoder
+
+import (
+	"github.com/DataDog/datadog-log-agent/pkg/message"
+)
+
+type MockPayloadContext struct {
+	Content []byte
+	Message []byte
+}
+
+func (c *MockPayloadContext) messageOrigin() *message.MessageOrigin {
+	c.Message = make([]byte, len(c.Content))
+	copy(c.Message, c.Content)
+	c.Content = c.Content[:0]
+	return nil
+}
+
+func (c *MockPayloadContext) update(content []byte) {
+	c.Content = append(c.Content, content...)
+}

--- a/pkg/input/container/docker.go
+++ b/pkg/input/container/docker.go
@@ -137,7 +137,7 @@ func (dt *DockerTailer) readForever() {
 			dt.wait()
 			continue
 		}
-		dt.d.InputChan <- decoder.NewPayload(inBuf[:n])
+		dt.d.InputChan <- decoder.NewPayload(inBuf[:n], nil)
 	}
 }
 

--- a/pkg/input/container/docker.go
+++ b/pkg/input/container/docker.go
@@ -137,7 +137,7 @@ func (dt *DockerTailer) readForever() {
 			dt.wait()
 			continue
 		}
-		dt.d.InputChan <- decoder.NewPayload(inBuf[:n], 0)
+		dt.d.InputChan <- decoder.NewPayload(inBuf[:n])
 	}
 }
 

--- a/pkg/input/container/docker.go
+++ b/pkg/input/container/docker.go
@@ -48,7 +48,7 @@ func NewDockerTailer(cli *client.Client, container types.Container, source *conf
 	return &DockerTailer{
 		containerName: container.ID,
 		outputChan:    outputChan,
-		d:             decoder.InitializedDecoder(),
+		d:             decoder.InitializeDecoder(source),
 		source:        source,
 		cli:           cli,
 

--- a/pkg/input/listener/abstract_listener.go
+++ b/pkg/input/listener/abstract_listener.go
@@ -56,7 +56,7 @@ func (anl *AbstractNetworkListener) forwardMessages(d *decoder.Decoder, outputCh
 // handleConnection listens to messages sent on a given connection
 // and forwards them to an outputChan
 func (anl *AbstractNetworkListener) handleConnection(conn net.Conn) {
-	d := decoder.InitializedDecoder()
+	d := decoder.InitializedDecoder(anl.source)
 	d.Start()
 	go anl.forwardMessages(d, anl.pp.NextPipelineChan())
 	for {

--- a/pkg/input/listener/abstract_listener.go
+++ b/pkg/input/listener/abstract_listener.go
@@ -71,6 +71,6 @@ func (anl *AbstractNetworkListener) handleConnection(conn net.Conn) {
 			d.Stop()
 			return
 		}
-		d.InputChan <- decoder.NewPayload(inBuf[:n]) // we don't pass an offset for a network message
+		d.InputChan <- decoder.NewPayload(inBuf[:n], nil) // we don't pass an offset for a network message
 	}
 }

--- a/pkg/input/listener/abstract_listener.go
+++ b/pkg/input/listener/abstract_listener.go
@@ -71,6 +71,6 @@ func (anl *AbstractNetworkListener) handleConnection(conn net.Conn) {
 			d.Stop()
 			return
 		}
-		d.InputChan <- decoder.NewPayload(inBuf[:n], 0) // we don't pass an offset for a network message
+		d.InputChan <- decoder.NewPayload(inBuf[:n]) // we don't pass an offset for a network message
 	}
 }

--- a/pkg/input/listener/abstract_listener.go
+++ b/pkg/input/listener/abstract_listener.go
@@ -56,7 +56,7 @@ func (anl *AbstractNetworkListener) forwardMessages(d *decoder.Decoder, outputCh
 // handleConnection listens to messages sent on a given connection
 // and forwards them to an outputChan
 func (anl *AbstractNetworkListener) handleConnection(conn net.Conn) {
-	d := decoder.InitializedDecoder(anl.source)
+	d := decoder.InitializeDecoder(anl.source)
 	d.Start()
 	go anl.forwardMessages(d, anl.pp.NextPipelineChan())
 	for {

--- a/pkg/input/tailer/tailer.go
+++ b/pkg/input/tailer/tailer.go
@@ -50,7 +50,7 @@ func NewTailer(outputChan chan message.Message, source *config.IntegrationConfig
 	return &Tailer{
 		path:       source.Path,
 		outputChan: outputChan,
-		d:          decoder.InitializedDecoder(),
+		d:          decoder.InitializedDecoder(source),
 		source:     source,
 
 		lastOffset:        0,

--- a/pkg/input/tailer/tailer.go
+++ b/pkg/input/tailer/tailer.go
@@ -50,7 +50,7 @@ func NewTailer(outputChan chan message.Message, source *config.IntegrationConfig
 	return &Tailer{
 		path:       source.Path,
 		outputChan: outputChan,
-		d:          decoder.InitializedDecoder(source),
+		d:          decoder.InitializeDecoder(source),
 		source:     source,
 
 		lastOffset:        0,

--- a/pkg/input/tailer/tailer.go
+++ b/pkg/input/tailer/tailer.go
@@ -150,7 +150,7 @@ func (t *Tailer) forwardMessages() {
 		}
 
 		fileMsg := message.NewFileMessage(msg.Content())
-		msgOffset := msg.GetOrigin().Offset
+		msgOffset := t.lastOffset + int64(len(msg.Content())+1)
 		identifier := t.Identifier()
 		if !t.shouldTrackOffset {
 			msgOffset = 0
@@ -192,7 +192,7 @@ func (t *Tailer) readForever() {
 			t.wait()
 			continue
 		}
-		t.d.InputChan <- decoder.NewPayload(inBuf[:n], t.GetLastOffset())
+		t.d.InputChan <- decoder.NewPayload(inBuf[:n])
 		t.incrementLastOffset(n)
 	}
 }

--- a/pkg/input/tailer/tailer.go
+++ b/pkg/input/tailer/tailer.go
@@ -150,7 +150,7 @@ func (t *Tailer) forwardMessages() {
 		}
 
 		fileMsg := message.NewFileMessage(msg.Content())
-		msgOffset := t.lastOffset + int64(len(msg.Content())+1)
+		msgOffset := msg.GetOrigin().Offset
 		identifier := t.Identifier()
 		if !t.shouldTrackOffset {
 			msgOffset = 0
@@ -192,7 +192,9 @@ func (t *Tailer) readForever() {
 			t.wait()
 			continue
 		}
-		t.d.InputChan <- decoder.NewPayload(inBuf[:n])
+		offset := t.GetLastOffset()
+		payloadOrigin := decoder.NewFileContext(offset)
+		t.d.InputChan <- decoder.NewPayload(inBuf[:n], payloadOrigin)
 		t.incrementLastOffset(n)
 	}
 }


### PR DESCRIPTION
Changed the decoder and the integration config to support multiline-logs.

If you want to test, don't forget to change your logs-integrations.yaml and add the multi-line processing rule (see bellow).

```
...
logs:
  - type: file
    path: /home/vagrant/test.log
    appname: bench-logs-agent
    source: bench-logs-agent
    logset: playground
    log_processing_rules:
      - type: multi_line
        name: numbers
        pattern: "[0-9]+"
...
```