### PR TITLE
Added multi-line support to logs-agent

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -15,9 +15,7 @@ const (
 // Business constants
 
 const (
-	// MaxMessageLen is the maximum length for any message we send to the intake
-	MaxMessageLen = 1 * 1000 * 1000
-	DateFormat    = "2006-01-02T15:04:05.000000000Z"
+	DateFormat = "2006-01-02T15:04:05.000000000Z"
 )
 
 var (

--- a/pkg/config/integration_config.go
+++ b/pkg/config/integration_config.go
@@ -22,6 +22,7 @@ const (
 	DOCKER_TYPE      = "docker"
 	EXCLUDE_AT_MATCH = "exclude_at_match"
 	MASK_SEQUENCES   = "mask_sequences"
+	MULTILINE        = "multi_line"
 )
 
 const INTEGRATION_CONFIG_EXTENTION = ".yaml"
@@ -184,6 +185,8 @@ func validateProcessingRules(rules []LogsProcessingRule) ([]LogsProcessingRule, 
 		case MASK_SEQUENCES:
 			rules[i].Reg = regexp.MustCompile(rule.Pattern)
 			rules[i].ReplacePlaceholderBytes = []byte(rule.ReplacePlaceholder)
+		case MULTILINE:
+			rules[i].Reg = regexp.MustCompile("^" + rule.Pattern)
 		default:
 			if rule.Type == "" {
 				return nil, fmt.Errorf("LogsAgent misconfigured: type must be set for log processing rule `%s`", rule.Name)

--- a/pkg/config/integration_config_test.go
+++ b/pkg/config/integration_config_test.go
@@ -46,13 +46,21 @@ func TestBuildLogsAgentIntegrationsConfigs(t *testing.T) {
 
 	// processing
 	assert.Equal(t, 0, len(rules[0].ProcessingRules))
-	assert.Equal(t, 1, len(rules[1].ProcessingRules))
+	assert.Equal(t, 2, len(rules[1].ProcessingRules))
+
 	pRule := rules[1].ProcessingRules[0]
 	assert.Equal(t, "mask_sequences", pRule.Type)
 	assert.Equal(t, "mocked_mask_rule", pRule.Name)
 	assert.Equal(t, "[mocked]", pRule.ReplacePlaceholder)
 	assert.Equal(t, []byte("[mocked]"), pRule.ReplacePlaceholderBytes)
 	assert.Equal(t, ".*", pRule.Pattern)
+
+	mRule := rules[1].ProcessingRules[1]
+	assert.Equal(t, "multi_line", mRule.Type)
+	assert.Equal(t, "numbers", mRule.Name)
+	re := mRule.Reg
+	assert.True(t, re.MatchString("123"))
+	assert.False(t, re.MatchString("a123"))
 }
 
 func TestBuildTagsPayload(t *testing.T) {

--- a/pkg/config/tests/complete/conf.d/integration2.yaml
+++ b/pkg/config/tests/complete/conf.d/integration2.yaml
@@ -11,4 +11,7 @@ logs:
       - type: mask_sequences
         name: mocked_mask_rule
         replace_placeholder: "[mocked]"
-        pattern: ".*" 
+        pattern: ".*"
+      - type: multi_line
+        name: numbers
+        pattern: "^[0-9]"

--- a/pkg/decoder/decoder_test.go
+++ b/pkg/decoder/decoder_test.go
@@ -7,102 +7,221 @@ package decoder
 
 import (
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-log-agent/pkg/config"
-	"github.com/DataDog/datadog-log-agent/pkg/message"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDecodeIncomingData(t *testing.T) {
-	outChan := make(chan message.Message, 10)
-	d := New(nil, outChan)
+func TestDecodeIncomingDataForSingleLineLogs(t *testing.T) {
+	outChan := make(chan *Output, 10)
+	d := New(nil, outChan, NewSingleLineHandler(outChan))
 
-	var out message.Message
+	var out *Output
 
 	// multiple messages in one buffer
-	d.decodeIncomingData([]byte(("helloworld\n")), 0)
+	d.decodeIncomingData([]byte("helloworld\n"))
 	out = <-outChan
-	assert.Equal(t, "helloworld", string(out.Content()))
-	assert.Equal(t, "", d.msgBuffer.String())
-	d.msgBuffer.Reset()
+	assert.Equal(t, "helloworld", string(out.Content))
+	assert.Equal(t, "", d.lineBuffer.String())
 
-	d.decodeIncomingData([]byte(("helloworld\nhowayou\ngoodandyou")), 0)
+	d.decodeIncomingData([]byte("helloworld\nhowayou\ngoodandyou"))
 	out = <-outChan
-	assert.Equal(t, "helloworld", string(out.Content()))
+	assert.Equal(t, "helloworld", string(out.Content))
 	out = <-outChan
-	assert.Equal(t, "howayou", string(out.Content()))
-	assert.Equal(t, "goodandyou", d.msgBuffer.String())
-	d.msgBuffer.Reset()
+	assert.Equal(t, "howayou", string(out.Content))
+	assert.Equal(t, "goodandyou", d.lineBuffer.String())
+	d.lineBuffer.Reset()
 
 	// messages overflow in the next buffer
-	d.decodeIncomingData([]byte(("helloworld\nthisisa")), 5)
-	assert.Equal(t, "thisisa", d.msgBuffer.String())
-	d.decodeIncomingData([]byte(("longinput\nindeed")), 15)
+	d.decodeIncomingData([]byte("helloworld\nthisisa"))
+	assert.Equal(t, "thisisa", d.lineBuffer.String())
+	d.decodeIncomingData([]byte("longinput\nindeed"))
 	out = <-outChan
 	out = <-outChan
-	assert.Equal(t, "thisisalonginput", string(out.Content()))
-	assert.Equal(t, "indeed", d.msgBuffer.String())
-	d.msgBuffer.Reset()
+	assert.Equal(t, "thisisalonginput", string(out.Content))
+	assert.Equal(t, "indeed", d.lineBuffer.String())
+	d.lineBuffer.Reset()
 
 	// edge cases, do not crash
-	d.decodeIncomingData([]byte(("\n\n")), 0)
-	d.decodeIncomingData([]byte(("")), 0)
+	d.decodeIncomingData([]byte("\n\n"))
+	d.decodeIncomingData([]byte(""))
+	d.lineBuffer.Reset()
 
 	// buffer overflow
-	d.msgBuffer.Reset()
-	d.decodeIncomingData([]byte(("hello world")), 0)
-	d.decodeIncomingData([]byte(("!\n")), 0)
+	d.decodeIncomingData([]byte("hello world"))
+	d.decodeIncomingData([]byte("!\n"))
 	out = <-outChan
-	assert.Equal(t, "hello world!", string(out.Content()))
+	assert.Equal(t, "hello world!", string(out.Content))
+	d.lineBuffer.Reset()
 
 	// message too big
-	d.msgBuffer.Reset()
-	d.decodeIncomingData([]byte((strings.Repeat("a", config.MaxMessageLen+5) + "\n")), 0)
+	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit+10) + "\n"))
 	out = <-outChan
-	assert.Equal(t, config.MaxMessageLen, len(out.Content()))
+	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
 	out = <-outChan
-	assert.Equal(t, "...TRUNCATED..."+strings.Repeat("a", 20), string(out.Content()))
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
+	d.lineBuffer.Reset()
 
 	// message too big, over several calls
-	d.decodeIncomingData([]byte((strings.Repeat("a", config.MaxMessageLen-20))), 0)
-	d.decodeIncomingData([]byte((strings.Repeat("a", 25) + "\n")), 0)
+	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit-5)))
+	d.decodeIncomingData([]byte(strings.Repeat("a", 15) + "\n"))
 	out = <-outChan
-	assert.Equal(t, config.MaxMessageLen, len(out.Content()))
+	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
 	out = <-outChan
-	assert.Equal(t, "...TRUNCATED..."+strings.Repeat("a", 20), string(out.Content()))
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
+	d.lineBuffer.Reset()
 
-	// message too big
-	d.msgBuffer.Reset()
-	d.decodeIncomingData([]byte((strings.Repeat("a", config.MaxMessageLen-15) + "\n")), 0)
+	// message twice too big
+	d.decodeIncomingData([]byte(strings.Repeat("a", 2*contentLenLimit+10) + "\n"))
 	out = <-outChan
-	assert.Equal(t, config.MaxMessageLen-15, len(out.Content()))
+	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
+	out = <-outChan
+	assert.Equal(t, len(TRUNCATED)+contentLenLimit+len(TRUNCATED), len(out.Content))
+	out = <-outChan
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
 
-	// decoder offset management
-	d.msgBuffer.Reset()
-	d.decodeIncomingData([]byte(("6789\n121416182022\n2527")), 5)
-	d.decodeIncomingData([]byte(("29\n")), 27)
+	// message twice too big, over several calls
+	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit+5)))
+	d.decodeIncomingData([]byte(strings.Repeat("a", contentLenLimit+5) + "\n"))
 	out = <-outChan
-	assert.Equal(t, int64(10), out.GetOrigin().Offset)
+	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
 	out = <-outChan
-	assert.Equal(t, int64(23), out.GetOrigin().Offset)
+	assert.Equal(t, len(TRUNCATED)+contentLenLimit+len(TRUNCATED), len(out.Content))
 	out = <-outChan
-	assert.Equal(t, int64(30), out.GetOrigin().Offset)
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
+	d.lineBuffer.Reset()
 }
 
-func TestDecoderLifecycle(t *testing.T) {
-	inChan := make(chan *Payload, 10)
-	outChan := make(chan message.Message, 10)
-	d := New(inChan, outChan)
-	d.Start()
-	var out message.Message
+func TestDecodeIncomingDataForMultiLineLogs(t *testing.T) {
+	inChan := make(chan *Input, 10)
+	outChan := make(chan *Output, 10)
+	re := regexp.MustCompile("[0-9]+\\.")
+	d := New(inChan, outChan, NewMultiLineLineHandler(outChan, re))
 
-	inChan <- NewPayload([]byte(("helloworld\n")), 0)
+	var out *Output
+	go d.Start()
+
+	// two lines message in one raw data
+	inChan <- NewInput([]byte("1. Hello\nworld!\n"))
 	out = <-outChan
-	assert.Equal(t, "helloworld", string(out.Content()))
+	assert.Equal(t, "1. Hello\\nworld!", string(out.Content))
+	assert.Equal(t, "", d.lineBuffer.String())
+
+	// multiple messages in one raw data
+	inChan <- NewInput([]byte("1. Hello\nworld!\n2. How are you\n"))
+	out = <-outChan
+	assert.Equal(t, "1. Hello\\nworld!", string(out.Content))
+	out = <-outChan
+	assert.Equal(t, "2. How are you", string(out.Content))
+	assert.Equal(t, "", d.lineBuffer.String())
+
+	// two lines message over two raw data
+	inChan <- NewInput([]byte("1. Hello\n"))
+	inChan <- NewInput([]byte("world!\n"))
+	out = <-outChan
+	assert.Equal(t, "1. Hello\\nworld!", string(out.Content))
+	assert.Equal(t, "", d.lineBuffer.String())
+
+	// multiple messages accross two raw data
+	inChan <- NewInput([]byte("1. Hello\n"))
+	inChan <- NewInput([]byte("world!\n2. How are you\n"))
+	out = <-outChan
+	assert.Equal(t, "1. Hello\\nworld!", string(out.Content))
+	out = <-outChan
+	assert.Equal(t, "2. How are you", string(out.Content))
+	assert.Equal(t, "", d.lineBuffer.String())
+
+	// single-line message in one raw data
+	inChan <- NewInput([]byte("1. Hello world!\n"))
+	out = <-outChan
+	assert.Equal(t, "1. Hello world!", string(out.Content))
+	assert.Equal(t, "", d.lineBuffer.String())
+
+	// multiple single-line messages in one raw data
+	inChan <- NewInput([]byte("1. Hello world!\n2. How are you\n"))
+	out = <-outChan
+	assert.Equal(t, "1. Hello world!", string(out.Content))
+	out = <-outChan
+	assert.Equal(t, "2. How are you", string(out.Content))
+	assert.Equal(t, "", d.lineBuffer.String())
+
+	// two lines too big message in one raw data
+	inChan <- NewInput([]byte("12345678.\n" + strings.Repeat("a", contentLenLimit+10) + "\n"))
+	out = <-outChan
+	assert.Equal(t, 11+contentLenLimit+len(TRUNCATED), len(out.Content))
+	out = <-outChan
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
+
+	// two lines too big message in two raw data
+	inChan <- NewInput([]byte("12345678.\n"))
+	inChan <- NewInput([]byte(strings.Repeat("a", contentLenLimit+10) + "\n"))
+	out = <-outChan
+	assert.Equal(t, 11+contentLenLimit+len(TRUNCATED), len(out.Content))
+	out = <-outChan
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
+
+	// single-line too big message over two raw data
+	inChan <- NewInput([]byte(strings.Repeat("a", contentLenLimit)))
+	inChan <- NewInput([]byte(strings.Repeat("a", 10) + "\n"))
+	out = <-outChan
+	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
+	out = <-outChan
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
+
+	// single-line too big message in one raw data
+	inChan <- NewInput([]byte(strings.Repeat("a", contentLenLimit+10) + "\n"))
+	out = <-outChan
+	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
+	out = <-outChan
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
+
+	// message twice too big in one raw data
+	inChan <- NewInput([]byte(strings.Repeat("a", 2*contentLenLimit+10) + "\n"))
+	out = <-outChan
+	assert.Equal(t, contentLenLimit+len(TRUNCATED), len(out.Content))
+	out = <-outChan
+	assert.Equal(t, len(TRUNCATED)+contentLenLimit+len(TRUNCATED), len(out.Content))
+	out = <-outChan
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
+
+	// message twice too big over two raw data
+	inChan <- NewInput([]byte(strings.Repeat("a", contentLenLimit+5)))
+	inChan <- NewInput([]byte(strings.Repeat("a", contentLenLimit+5) + "\n"))
+	out = <-outChan
+	assert.Equal(t, len(TRUNCATED)+contentLenLimit, len(out.Content))
+	out = <-outChan
+	assert.Equal(t, len(TRUNCATED)+contentLenLimit+len(TRUNCATED), len(out.Content))
+	out = <-outChan
+	assert.Equal(t, string(TRUNCATED)+strings.Repeat("a", 10), string(out.Content))
+
+	// pending message in one raw data
+	d.decodeIncomingData([]byte("1. Hello world!"))
+	assert.Equal(t, "1. Hello world!", string(d.lineBuffer.Bytes()))
+	d.decodeIncomingData([]byte("\n"))
+	out = <-outChan
+	assert.Equal(t, "1. Hello world!", string(out.Content))
+}
+
+func TestSingleLineDecoderLifecycle(t *testing.T) {
+	inChan := make(chan *Input, 10)
+	outChan := make(chan *Output, 10)
+	d := New(inChan, outChan, NewSingleLineHandler(outChan))
+	d.Start()
 
 	d.Stop()
-	out = <-outChan
-	assert.Equal(t, reflect.TypeOf(out), reflect.TypeOf(message.NewStopMessage()))
+	out := <-outChan
+	assert.Equal(t, reflect.TypeOf(out), reflect.TypeOf(newStopOutput()))
+}
+
+func TestMultiLineDecoderLifecycle(t *testing.T) {
+	inChan := make(chan *Input, 10)
+	outChan := make(chan *Output, 10)
+	d := New(inChan, outChan, NewMultiLineLineHandler(outChan, nil))
+	d.Start()
+
+	d.Stop()
+	out := <-outChan
+	assert.Equal(t, reflect.TypeOf(out), reflect.TypeOf(newStopOutput()))
 }

--- a/pkg/decoder/line_buffer.go
+++ b/pkg/decoder/line_buffer.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package decoder
+
+import (
+	"bytes"
+)
+
+// LineBuffer accumulates lines in buffer escaping all '\n'
+// and accumulates the total number of bytes of all lines in line representation (line + '\n') in contentLen
+// to form and forward outputs to outputChan
+type LineBuffer struct {
+	outputChan chan *Output
+	buffer     *bytes.Buffer
+	contentLen int
+}
+
+// NewLineBuffer returns a new LineBuffer
+func NewLineBuffer(outputChan chan *Output) *LineBuffer {
+	buffer := bytes.Buffer{}
+	return &LineBuffer{
+		outputChan: outputChan,
+		buffer:     &buffer,
+	}
+}
+
+// IsEmpty returns true if buffer does not contain any line
+func (l *LineBuffer) IsEmpty() bool {
+	return l.contentLen == 0
+}
+
+// Length returns the length of buffer which might be different from contentLen because of escaped '\n'
+func (l *LineBuffer) Length() int {
+	return l.buffer.Len()
+}
+
+// Add stores line in buffer
+func (l *LineBuffer) Add(line *Line) {
+	l.buffer.Write(line.content)
+	l.contentLen += len(line.content) + 1 // add 1 for '\n'
+}
+
+// AddEndOfLine stores an escaped '\n' in buffer
+func (l *LineBuffer) AddEndOfLine() {
+	l.buffer.Write([]byte(`\n`))
+}
+
+// AddIncompleteLine stores a chunck of line in buff
+func (l *LineBuffer) AddIncompleteLine(line *Line) {
+	l.buffer.Write(line.content)
+	l.contentLen += len(line.content)
+}
+
+// AddTruncate stores TRUNCATED in buffer
+func (l *LineBuffer) AddTruncate(line *Line) {
+	l.buffer.Write(TRUNCATED)
+}
+
+// send creates a new ouput from content in buffer and sends it to outputChan
+func (l *LineBuffer) Flush() {
+	defer l.reset()
+	content := make([]byte, l.buffer.Len())
+	copy(content, l.buffer.Bytes())
+	if len(content) > 0 {
+		output := NewOutput(content, l.contentLen)
+		l.outputChan <- output
+	}
+}
+
+// Stop forwards stop event to outputChan
+func (l *LineBuffer) Stop() {
+	l.outputChan <- newStopOutput()
+}
+
+// reset prepares buffer to receive new lines
+func (l *LineBuffer) reset() {
+	l.contentLen = 0
+	l.buffer.Reset()
+}

--- a/pkg/decoder/line_handler.go
+++ b/pkg/decoder/line_handler.go
@@ -1,0 +1,202 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2017 Datadog, Inc.
+
+package decoder
+
+import (
+	"regexp"
+	"sync"
+	"time"
+)
+
+// TRUNCATED is the warning we add at the beginning or/and at the end of a truncated message
+var TRUNCATED = []byte("...TRUNCATED...")
+
+// Line represents content separated by two '\n'
+type Line struct {
+	content []byte
+}
+
+// NewLine returns a new Line
+func NewLine(content []byte) *Line {
+	return &Line{
+		content: content,
+	}
+}
+
+// LineHandler handles Lines to form output
+type LineHandler interface {
+	Handle(line *Line)
+	Stop()
+}
+
+// SingleLineHandler creates and forward outputs to outputChan from single-lines
+type SingleLineHandler struct {
+	lineChan       chan *Line
+	outputChan     chan *Output
+	shouldTruncate bool
+}
+
+// NewSingleLineHandler returns a new SingleLineHandler
+func NewSingleLineHandler(outputChan chan *Output) *SingleLineHandler {
+	lineChan := make(chan *Line)
+	lineHandler := SingleLineHandler{
+		lineChan:   lineChan,
+		outputChan: outputChan,
+	}
+	go lineHandler.start()
+	return &lineHandler
+}
+
+// Handle forward lines to lineChan to process them
+func (lh *SingleLineHandler) Handle(line *Line) {
+	lh.lineChan <- line
+}
+
+// Stop stops the handler from processing new lines
+func (lh *SingleLineHandler) Stop() {
+	close(lh.lineChan)
+}
+
+// start consumes lines from lineChan to process them
+func (lh *SingleLineHandler) start() {
+	for line := range lh.lineChan {
+		lh.process(line)
+	}
+	lh.outputChan <- newStopOutput()
+}
+
+// process creates outputs from lines and forwards them to outputChan
+// When lines are too long, they are truncated
+func (lh *SingleLineHandler) process(line *Line) {
+	lineLen := len(line.content)
+	if lineLen == 0 {
+		return
+	}
+
+	var content []byte
+	if lh.shouldTruncate {
+		// add TRUNCATED at the beginning of content
+		content = append(TRUNCATED, line.content...)
+		lh.shouldTruncate = false
+	} else {
+		// keep content the same
+		content = line.content
+	}
+
+	if lineLen < contentLenLimit {
+		// send content
+		output := NewOutput(content, lineLen+1) // add 1 to take into account '\n'
+		lh.outputChan <- output
+	} else {
+		// add TRUNCATED at the end of content and send it
+		content := append(content, TRUNCATED...)
+		output := NewOutput(content, lineLen)
+		lh.outputChan <- output
+		lh.shouldTruncate = true
+	}
+}
+
+// flushTimeout represents the time we want to wait before flushing lineBuffer
+// when no more line is received
+const flushTimeout = 1 * time.Second
+
+// MultiLineLineHandler reads lines from lineChan and uses lineBuffer to send them
+// when a new line matches with re or flushTimer is fired
+type MultiLineLineHandler struct {
+	lineChan     chan *Line
+	lineBuffer   *LineBuffer
+	newContentRe *regexp.Regexp
+	flushTimer   *time.Timer
+	mu           sync.Mutex
+	shouldStop   bool
+}
+
+// NewMultiLineLineHandler returns a new MultiLineLineHandler
+func NewMultiLineLineHandler(outputChan chan *Output, newContentRe *regexp.Regexp) *MultiLineLineHandler {
+	lineChan := make(chan *Line)
+	lineBuffer := NewLineBuffer(outputChan)
+	flushTimer := time.NewTimer(flushTimeout)
+	lineHandler := MultiLineLineHandler{
+		lineChan:     lineChan,
+		lineBuffer:   lineBuffer,
+		newContentRe: newContentRe,
+		flushTimer:   flushTimer,
+	}
+	go lineHandler.start()
+	return &lineHandler
+}
+
+// Handle forward lines to lineChan to process them
+func (lh *MultiLineLineHandler) Handle(line *Line) {
+	lh.lineChan <- line
+}
+
+// Stop stops the lineHandler from processing lines
+func (lh *MultiLineLineHandler) Stop() {
+	lh.mu.Lock()
+	close(lh.lineChan)
+	lh.shouldStop = true
+	// assure to stop timer goroutine
+	lh.flushTimer.Reset(flushTimeout)
+	lh.mu.Unlock()
+}
+
+// start starts the delimiter
+func (lh *MultiLineLineHandler) start() {
+	go lh.handleExpiration()
+	go lh.run()
+}
+
+// run reads lines from lineChan to process them
+func (lh *MultiLineLineHandler) run() {
+	// read and process lines safely
+	for line := range lh.lineChan {
+		lh.mu.Lock()
+		// prevent timer from firing
+		lh.flushTimer.Stop()
+		lh.process(line)
+		// restart timer if no more lines are received
+		lh.flushTimer.Reset(flushTimeout)
+		lh.mu.Unlock()
+	}
+}
+
+// handleExpiration flushes content in lineBuffer when flushTimer expires
+func (lh *MultiLineLineHandler) handleExpiration() {
+	for range lh.flushTimer.C {
+		lh.mu.Lock()
+		lh.lineBuffer.Flush()
+		lh.mu.Unlock()
+		if lh.shouldStop {
+			break
+		}
+	}
+	lh.lineBuffer.Stop()
+}
+
+// process accumulates lines in lineBuffer and flushes lineBuffer when a new line matches with newContentRe
+// When lines are too long, they are truncated
+func (lh *MultiLineLineHandler) process(line *Line) {
+	if lh.newContentRe.Match(line.content) {
+		// send content in lineBuffer
+		lh.lineBuffer.Flush()
+	}
+	if !lh.lineBuffer.IsEmpty() {
+		// add '\n' to content in lineBuffer
+		lh.lineBuffer.AddEndOfLine()
+	}
+	if len(line.content)+lh.lineBuffer.Length() < contentLenLimit {
+		// add line to content in lineBuffer
+		lh.lineBuffer.Add(line)
+	} else {
+		// add line and truncate and flush content in lineBuffer
+		lh.lineBuffer.AddIncompleteLine(line)
+		lh.lineBuffer.AddTruncate(line)
+		lh.lineBuffer.Flush()
+		// truncate next content
+		lh.lineBuffer.AddTruncate(line)
+	}
+}

--- a/pkg/input/tailer/scanner.go
+++ b/pkg/input/tailer/scanner.go
@@ -113,8 +113,8 @@ func (s *Scanner) scan() {
 			continue
 		}
 
-		if stat1.Size() < tailer.GetLastOffset() {
-			tailer.reset()
+		if stat1.Size() < tailer.GetReadOffset() {
+			s.onFileRotation(tailer, source)
 		}
 	}
 }

--- a/pkg/input/tailer/scanner_test.go
+++ b/pkg/input/tailer/scanner_test.go
@@ -83,15 +83,15 @@ func (suite *ScannerTestSuite) TestScannerScanWithoutLogRotation() {
 	var newTailer *Tailer
 	var err error
 	var msg message.Message
-	var lastOffset int64
+	var readOffset int64
 
 	tailer = s.tailers[sources[0].Path]
 	_, err = suite.testFile.WriteString("hello world\n")
 	suite.Nil(err)
 	msg = <-suite.outputChan
 	suite.Equal("hello world", string(msg.Content()))
-	lastOffset = tailer.GetLastOffset()
-	suite.True(lastOffset > 0)
+	readOffset = tailer.GetReadOffset()
+	suite.True(readOffset > 0)
 
 	s.scan()
 	newTailer = s.tailers[sources[0].Path]
@@ -101,7 +101,7 @@ func (suite *ScannerTestSuite) TestScannerScanWithoutLogRotation() {
 	suite.Nil(err)
 	msg = <-suite.outputChan
 	suite.Equal("hello again", string(msg.Content()))
-	suite.True(tailer.GetLastOffset() > lastOffset)
+	suite.True(tailer.GetReadOffset() > readOffset)
 }
 
 func (suite *ScannerTestSuite) TestScannerScanWithLogRotation() {
@@ -155,8 +155,8 @@ func (suite *ScannerTestSuite) TestScannerScanWithLogRotationCopyTruncate() {
 	suite.Nil(err)
 	s.scan()
 	newTailer = s.tailers[sources[0].Path]
-	suite.Equal(tailer, newTailer)
-	suite.Equal(tailer.GetLastOffset(), int64(0))
+	suite.NotEqual(tailer, newTailer)
+	suite.Equal(newTailer.GetReadOffset(), int64(0))
 
 	msg = <-suite.outputChan
 	suite.Equal("third", string(msg.Content()))

--- a/pkg/input/tailer/tailer_test.go
+++ b/pkg/input/tailer/tailer_test.go
@@ -86,7 +86,7 @@ func writeMessage(file *os.File) {
 	file.WriteString("hello world\n")
 }
 
-func listenToChan(inputChan chan *decoder.Payload, messagesReceived *uint64) {
+func listenToChan(inputChan chan *decoder.Input, messagesReceived *uint64) {
 	for _ = range inputChan {
 		atomic.AddUint64(messagesReceived, 1)
 		tick()
@@ -104,16 +104,16 @@ func (suite *TailerTestSuite) TestTailerIsSlowAndCatchesUp() {
 	suite.tl.sleepDuration = time.Millisecond
 
 	// mock tailer output channel
-	suite.tl.d.InputChan = make(chan *decoder.Payload, 2)
+	suite.tl.d.InputChan = make(chan *decoder.Input, 2)
 	suite.tl.startReading(0, os.SEEK_END)
 
 	// fill output channel
-	of1 := suite.tl.GetLastOffset()
+	of1 := suite.tl.GetReadOffset()
 	for i := 0; i < 5; i++ {
 		writeMessage(suite.testFile)
 	}
 	// assert we read part of the file
-	of2 := suite.tl.GetLastOffset()
+	of2 := suite.tl.GetReadOffset()
 	suite.True(of1 < of2)
 
 	// assert reads are blocked: we write in the file but
@@ -121,7 +121,7 @@ func (suite *TailerTestSuite) TestTailerIsSlowAndCatchesUp() {
 	for i := 0; i < 5; i++ {
 		writeMessage(suite.testFile)
 	}
-	of3 := suite.tl.GetLastOffset()
+	of3 := suite.tl.GetReadOffset()
 	suite.Equal(of2, of3)
 
 	// slowly process all logs in the channel
@@ -153,7 +153,7 @@ func (suite *TailerTestSuite) TestTailerIsTooSlowAndClosed() {
 	tl.closeTimeout = 2 * time.Millisecond
 
 	// mock tailer output channel
-	tl.d.InputChan = make(chan *decoder.Payload, 2)
+	tl.d.InputChan = make(chan *decoder.Input, 2)
 	tl.startReading(0, os.SEEK_END)
 
 	// fill output channel

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -129,7 +129,7 @@ func (p *Processor) buildPayload(apikeyString, redactedMessage, extraContent []b
 		payload = append(payload, extraContent...)
 	}
 	payload = append(payload, redactedMessage...)
-	payload = append(payload, '\n')
+	payload = append(payload, '\n') // TODO: move this in decoder
 	return payload
 }
 

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -70,7 +70,7 @@ func TestExclusion(t *testing.T) {
 	assert.Equal(t, true, shouldProcess)
 }
 
-func TestRedacting(t *testing.T) {
+func TestMask(t *testing.T) {
 	p := NewTestProcessor()
 	var shouldProcess bool
 	var redactedMessage []byte
@@ -93,6 +93,15 @@ func TestRedacting(t *testing.T) {
 	shouldProcess, redactedMessage = p.applyRedactingRules(newNetworkMessage([]byte("The credit card 4323124312341234 was used to buy some time"), &source))
 	assert.Equal(t, true, shouldProcess)
 	assert.Equal(t, []byte("The credit card [masked_credit_card] was used to buy some time"), redactedMessage)
+}
+
+func TestTruncate(t *testing.T) {
+	p := NewTestProcessor()
+	source := config.IntegrationConfigLogSource{}
+	var redactedMessage []byte
+
+	_, redactedMessage = p.applyRedactingRules(newNetworkMessage([]byte("hello"), &source))
+	assert.Equal(t, []byte("hello"), redactedMessage)
 }
 
 func TestComputeExtraContent(t *testing.T) {


### PR DESCRIPTION
Added multi-line support for logs by:
- adding a new rule in integrations config 
- updating the decoder to decode either single-line or multi-line logs using a delimiter
- creating a single-line delimiter and a multi-line delimiter
- fixed concurrencies issues that could happen in multi-line delimiter
- created a helper to ease multi-lines buffering
- reduced the size limit of messages that are sent to the intake from 1MB to 256KB with a worse case scenario around 512KB
- moved the offset management from the decoder to the tailer
- kept the truncate logic in the decoder but isolated it inside the line buffer

TODO:
- Challenge LineHandler
- change the intake to replace '\' + '\n' by '\n' in all log messages

