### PR TITLE
Prevent docker message parsing to panic with unexpected messages

### DIFF
--- a/pkg/input/container/docker.go
+++ b/pkg/input/container/docker.go
@@ -255,11 +255,6 @@ func (dt *DockerTailer) parseMessage(msg []byte) (string, []byte, []byte, error)
 	return ts, sev, msg[to+1:], nil
 }
 
-// isValidMessage makes sure the raw docker message is valid.
-func (dt *DockerTailer) isValidMessage(msg []byte) bool {
-	return len(msg) > messageHeaderLength
-}
-
 // wait lets the reader sleep for a bit
 func (dt *DockerTailer) wait() {
 	time.Sleep(dt.sleepDuration)

--- a/pkg/input/container/docker.go
+++ b/pkg/input/container/docker.go
@@ -236,7 +236,7 @@ func (dt *DockerTailer) parseMessage(msg []byte) (string, []byte, []byte, error)
 	// [8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}[]byte{OUTPUT}
 	// If we don't have at the very least 8 bytes we can consider this message can't be parsed.
 	if len(msg) < messageHeaderLength {
-		return "", nil, nil, errors.New("Can't parse docker message: expected a 8 header bytes")
+		return "", nil, nil, errors.New("Can't parse docker message: expected a 8 bytes header")
 	}
 
 	// First byte is 1 for stdout and 2 for stderr

--- a/pkg/input/container/docker_test.go
+++ b/pkg/input/container/docker_test.go
@@ -80,7 +80,7 @@ func (suite *DockerTailerTestSuite) TestParseMessage() {
 	msg := []byte{}
 	msg = append(msg, []byte{1, 0, 0, 0, 0}...)
 	_, _, _, err := suite.tailer.parseMessage(msg)
-	suite.Equal(errors.New("Can't parse docker message: expected a 8 header bytes"), err)
+	suite.Equal(errors.New("Can't parse docker message: expected a 8 bytes header"), err)
 
 	msg = []byte{}
 	msg = append(msg, []byte{1, 0, 0, 0, 0, 62, 49, 103}...)


### PR DESCRIPTION
When tailing docker logs, the format we expect to receive is:
```
[8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}[]byte{OUTPUT}
```
Ref: https://godoc.org/github.com/moby/moby/client#Client.ContainerLogs

We have seen client reports where the agent receives empty messages such as:
```
[1 0 0 0 0 0]
```

This is reproducible for example while tailing logs from `cassandra:2.1.19` using `docker:17.06.0-ce`.

This PR allows the agent to detect such messages to avoid running into a panic.
